### PR TITLE
#3 Make emscripten module build and import browserify-friendly

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "mocha dist/test/*.spec.js",
     "clean": "rm -rf dist; rm -rf coverage; rm -rf dist_map",
     "clean-test": "rm -rf dist/test dist/build",
-    "tslint": "tslint --project='tsconfig.json'",
+    "tslint": "tslint --project tsconfig.json",
     "tsc": "tsc",
     "buildDebug": "tsc && node ./dist/build/make.js",
     "prebuildRelease": "npm run tslint",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "prebuildRelease": "npm run tslint",
     "buildRelease": "npm run clean && tsc && node ./dist/build/make.js release",
     "debug": "npm run test -- --debug-brk --inspect",
-
     "coverage": "tsc --sourceMap --outDir dist_map && istanbul cover node_modules/.bin/_mocha -- dist_map/test/*.spec.js",
     "browserify": "mkdir umd; browserify dist/index.js -s array-diff -o umd/array-diff.js"
   },
@@ -32,9 +31,10 @@
   "devDependencies": {
     "@types/mocha": "^2.2.40",
     "@types/shelljs": "^0.7.0",
+    "browserify": "^17.0.0",
     "mocha": "^3.2.0",
     "shelljs": "^0.7.7",
     "tslint": "^5.0.0",
-    "typescript": "^2.2.2"
+    "typescript": "^3.5.1"
   }
 }

--- a/src/build/make.ts
+++ b/src/build/make.ts
@@ -76,6 +76,7 @@ shjs.exec([
   "-std=c++14",
   "-s ALLOW_MEMORY_GROWTH=1",
   "-s DISABLE_EXCEPTION_CATCHING=0",
+  "-s MODULARIZE=1",
   "--memory-init-file 0",
   release ? "-O3" : "-g4",
   "--js-library ./src/cpp/bridge/bridge.js",

--- a/src/js/dataExtractor.ts
+++ b/src/js/dataExtractor.ts
@@ -1,6 +1,6 @@
 import {DataFile} from "./dataFile";
 import {Extractor, SeekMethod} from "./extractor";
-import * as unrar from "./unrar";
+import unrar from "./unrarSingleton";
 
 export class DataExtractor extends Extractor {
   protected _filePath: string;

--- a/src/js/extractor.ts
+++ b/src/js/extractor.ts
@@ -1,6 +1,6 @@
 
 import { Ext as extIns } from "./extractorCurrent";
-import * as unrar from "./unrar";
+import unrar from "./unrarSingleton";
 
 export type SeekMethod = "CUR" | "SET" | "END";
 

--- a/src/js/fileExtractor.ts
+++ b/src/js/fileExtractor.ts
@@ -2,7 +2,7 @@ import * as fs from "fs";
 import * as path from "path";
 
 import { Extractor, SeekMethod } from "./extractor";
-import * as unrar from "./unrar";
+import unrar from "./unrarSingleton";
 
 export class FileExtractor extends Extractor {
   protected _filePath: string;

--- a/src/js/unrarSingleton.ts
+++ b/src/js/unrarSingleton.ts
@@ -1,5 +1,5 @@
 import * as unrarCls from "./unrar";
 
-const unrar = new (<any>unrarCls);
+const unrar = new (unrarCls as any)();
 
 export default unrar;

--- a/src/js/unrarSingleton.ts
+++ b/src/js/unrarSingleton.ts
@@ -1,0 +1,5 @@
+import * as unrarCls from "./unrar";
+
+const unrar = new (<any>unrarCls);
+
+export default unrar;

--- a/tslint.json
+++ b/tslint.json
@@ -8,6 +8,7 @@
         "object-literal-sort-keys": false,
         "no-unused-expression": false,
         "prefer-const": false,
+        "no-shadowed-variable": false,
         "variable-name": false
     }
 }


### PR DESCRIPTION
Solves the "unrar.RarArchive is not a constructor"

https://github.com/YuJianrong/node-unrar.js/issues/3