### PR TITLE
Return the files listed so far instead of null even in case of archive error in getFileList()

### DIFF
--- a/src/js/extractor.ts
+++ b/src/js/extractor.ts
@@ -145,15 +145,16 @@ export abstract class Extractor {
         }
         fileHeaders.push(arcFile!.fileHeader);
       }
+      let extracted = {
+        arcHeader: arcHeader!,
+        fileHeaders,
+      };
       if ((fileState as { reason: FailReason }).reason !== "ERAR_END_ARCHIVE") {
-        ret = [fileState, null];
+        ret = [fileState, extracted];
       } else {
         ret = [{
           state: "SUCCESS",
-        }, {
-          arcHeader: arcHeader!,
-          fileHeaders,
-        }];
+        }, extracted];
       }
     }
     this.closeArc();


### PR DESCRIPTION

This allows to process incomplete RAR files: a partial buffer from stream for example. In my case I have like 50 MiB archive loading slower than 1 MiB/s and being able to continuously list files while archive is still loading would be a really nice user experience.

I don't insist on this change, but if you agree it is useful, it would be cool if it got accepted

If something else is needed for this PR to go through, just let me know, I have no life luckily ^_^