### PR TITLE
fix: remove the postinstall script which should not be executed when installed on user side

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,7 @@ jobs:
           cache: "npm"
           node-version: 18.x
       - run: npm ci
+      - run: npm run downloadUnrarSrc
       - run: npm run build:release
       - run: npm test
       - run: npm run clean:test

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ If you want to compile the module by yourself, please follow the steps below:
 
 - Download the c++ source of unRar library by:
 
-`npm run prepare`
+`npm run downloadUnrarSrc`
 
 - Build for debug:
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "module": "./esm/index.esm.js",
   "scripts": {
     "prepare": "husky install",
+    "downloadUnrarSrc": "wget https://www.rarlab.com/rar/unrarsrc-6.1.7.tar.gz && tar -xf unrarsrc-6.1.7.tar.gz -C src/cpp && rm -rf unrarsrc-6.1.7.tar.gz && husky install",
     "clean": "rm -rf dist coverage dist_map esm",
     "clean:test": "rm -rf dist/test dist/build esm/test esm/build dist/**/*.map esm/**/*.map",
     "commit": "cz",
@@ -19,7 +20,6 @@
     "build:debug": "tsc && node ./dist/build/make.js",
     "prebuild:release": "npm run lint",
     "build:release": "npm run clean && tsc && node ./dist/build/make.js release && tsc -p tsconfig-esm.json && node ./dist/build/make.js release esm",
-    "postinstall": "wget https://www.rarlab.com/rar/unrarsrc-6.1.7.tar.gz && tar -xf unrarsrc-6.1.7.tar.gz -C src/cpp && rm -rf unrarsrc-6.1.7.tar.gz",
     "test": "mocha dist/test/*.spec.js",
     "test:debug": "npm run test -- --inspect-brk"
   },


### PR DESCRIPTION
`wget` and `tar` are running incorrectly on `postinstall`, which is not required for installation.

fix #324